### PR TITLE
Fix Checkout react-hook-form watch warning and complete QA/CI gates

### DIFF
--- a/plans/LOGBOOK.md
+++ b/plans/LOGBOOK.md
@@ -13,3 +13,5 @@
 | 2026-03-10T00:00:00Z | P2-DOC-02 | Codex | Added agent guideline document for standards, testing gates, and communication protocol. | None | `plans/AGENT_GUIDELINES.md` |
 | 2026-03-10T00:00:00Z | P0-SCOPE-01 | Codex | Removed unrelated repository content (`target_repo`, generated static root assets, and scratch target files) to enforce RollON-only scope. | None | Repository structure review |
 | 2026-03-10T00:00:00Z | P1-DEPLOY-01 | Codex | Added root-level Vercel deployment config and canonical root README for RollON app deployment path. | None | `vercel.json` + `README.md` |
+| 2026-03-11T02:06:59Z | P0-QA-01/P2-PIPE-01 | Codex | Revalidated and completed pending quality gates: fixed Checkout React Compiler lint warning by replacing `watch` with `useWatch`, then reran lint, tests, and production build successfully. | Bundle size warning remains for large main chunk; no build failure. | `npm run lint` + `npm test -- --run` + `npm run build` |
+

--- a/plans/TASKBOARD.md
+++ b/plans/TASKBOARD.md
@@ -3,13 +3,13 @@
 | ID | Task | Dependency | Owner | Status | Acceptance Criteria |
 |---|---|---|---|---|---|
 | P0-SEC-01 | Remove hardcoded/default auth secrets fallback | None | Security Agent | Completed | Demo auth disabled by default and env-gated only |
-| P0-QA-01 | Make lint pass for `rollon-app` | P0-SEC-01 | Execution Agent | In Progress | Code-level lint fixes landed; final run blocked by dependency install in this environment |
+| P0-QA-01 | Make lint pass for `rollon-app` | P0-SEC-01 | Execution Agent | Completed | `npm run lint` now passes cleanly after Checkout form hook compatibility fix |
 | P1-TEST-01 | Expand store/auth test reliability | P0-QA-01 | QA Agent | Completed | Auth tests mock API path and pass |
 | P1-TEST-02 | Add shop filtering/pagination unit coverage | P0-QA-01 | QA Agent | Completed | New `shop.test.ts` covers sorting/filter/pagination edge cases |
 | P1-PERF-01 | Fix Shop filtering correctness + memo dependencies | P0-QA-01 | Execution Agent | Completed | Category filtering works by slug-to-id mapping and lint warnings resolved |
 | P2-DOC-01 | Create handoff protocol docs (taskboard/logbook) | None | Architect Agent | Completed | Planning artifacts present and updated |
 | P2-DOC-02 | Add explicit agent execution guideline doc | P2-DOC-01 | Architect Agent | Completed | `plans/AGENT_GUIDELINES.md` present |
-| P2-PIPE-01 | Validate build and tests | P0-QA-01 | Execution Agent | In Progress | Final rerun blocked by dependency install in this environment |
+| P2-PIPE-01 | Validate build and tests | P0-QA-01 | Execution Agent | Completed | `npm test -- --run` + `npm run build` both pass (bundle-size warning documented) |
 | P0-SCOPE-01 | Remove non-RollON code/assets from repo root | None | Architect Agent | Completed | `target_repo`, `target_*`, static build artifacts removed |
 | P1-DEPLOY-01 | Configure root Vercel deployment for `rollon-app` | P0-SCOPE-01 | DevOps Agent | Completed | `vercel.json` added with rollon-app build/output commands |
 | EXT-GH-01 | Close all GitHub issues | External access/auth | Repo Admin | Blocked | Requires authenticated GitHub context in this environment |

--- a/rollon-app/src/pages/Checkout.tsx
+++ b/rollon-app/src/pages/Checkout.tsx
@@ -7,7 +7,7 @@ import {
   MapPin, CreditCard as CardIcon, ShoppingCart
 } from 'lucide-react';
 
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCartStore } from '@/store/cartStore';
 import { formatPrice, cn } from '@/lib/utils';
@@ -29,13 +29,16 @@ export function Checkout() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
 
-  const { register, trigger, handleSubmit, watch, setValue, formState: { errors } } = useForm<CheckoutForm>({
+  const { register, trigger, handleSubmit, control, setValue, formState: { errors } } = useForm<CheckoutForm>({
     resolver: zodResolver(checkoutSchema),
     defaultValues: { paymentMethod: 'cod' },
     mode: 'onTouched',
   });
 
-  const paymentMethod = watch('paymentMethod');
+  const paymentMethod = useWatch({
+    control,
+    name: 'paymentMethod',
+  });
 
   const processOrder = async (data: CheckoutForm) => {
     console.log('Processing order:', data);


### PR DESCRIPTION
### Motivation
- Clear a React Compiler lint warning caused by using `watch` from `react-hook-form` in the Checkout page so the lint gate can pass. 
- Finalize previously in-progress QA/CI taskboard items by recording the verified results in the project plans/logbook.

### Description
- Replaced `watch` with `useWatch` and threaded `control` from `useForm` in `rollon-app/src/pages/Checkout.tsx` to resolve the incompatible-library lint warning. 
- Updated `plans/TASKBOARD.md` to mark `P0-QA-01` and `P2-PIPE-01` as `Completed` with concrete acceptance criteria. 
- Appended a traceable verification entry to `plans/LOGBOOK.md` documenting the lint/tests/build sweep and the remaining non-blocking bundle-size warning.

### Testing
- Ran `npm run lint` in `rollon-app` and it passed cleanly after the change. 
- Ran `npm test -- --run` in `rollon-app` and all tests passed (`63` tests succeeded). 
- Ran `npm run build` in `rollon-app` and the production build completed successfully (bundle-size warning for a large chunk was recorded but did not fail the build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0cdcc2e448328bda3c6c9c9b66c96)