### PR TITLE
Add Upstash-backed serverless API, seed data, and frontend remote API fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ See `rollon-app/.env.example`:
 
 | Variable | Description |
 |----------|-------------|
-| `VITE_API_URL` | Backend API URL |
+| `VITE_API_BASE_URL` | Frontend API base path (default `/api`) |
+| `VITE_USE_REMOTE_API` | Set `true` to use Vercel serverless + Upstash |
+| `RollON_Database_KV_REST_API_URL` | Upstash REST endpoint for serverless API |
+| `RollON_Database_KV_REST_API_TOKEN` | Upstash REST write token (server-side only) |
+| `ROLLON_ADMIN_SEED_TOKEN` | Protects `/api/admin/seed` endpoint |
 | `VITE_SSLCOMMERZ_*` | Payment gateway (Bangladesh) |
 | `VITE_BKASH_*` | bKash payment |
 | `VITE_ENABLE_DEMO_AUTH` | Set `false` in production |
@@ -83,6 +87,13 @@ rollon-app/
 ├── public/            # Static assets
 └── dist/              # Production build
 ```
+
+## 🗄️ Database
+
+- Upstash Redis-backed serverless API implemented under `/api/*`
+- Key schema documented in `docs/database-architecture.md`
+- Catalog research notes (Facebook metadata + data sourcing): `docs/catalog-research.md`
+- React frontend can use remote API or local fallback mode
 
 ## 🔐 Security
 

--- a/api/_lib/http.js
+++ b/api/_lib/http.js
@@ -1,0 +1,22 @@
+function sendJson(res, statusCode, payload) {
+  res.status(statusCode).json(payload);
+}
+
+function withErrorHandling(handler) {
+  return async (req, res) => {
+    try {
+      await handler(req, res);
+    } catch (error) {
+      console.error(error);
+      sendJson(res, 500, {
+        error: 'Internal server error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}
+
+module.exports = {
+  sendJson,
+  withErrorHandling,
+};

--- a/api/_lib/repositories.js
+++ b/api/_lib/repositories.js
@@ -1,0 +1,106 @@
+const { runCommand, runPipeline } = require('./upstash');
+
+const KEYS = {
+  products: 'rollon:idx:products',
+  categories: 'rollon:idx:categories',
+  orders: 'rollon:idx:orders',
+  customers: 'rollon:idx:customers',
+};
+
+function productKey(id) {
+  return `rollon:product:${id}`;
+}
+
+function categoryKey(id) {
+  return `rollon:category:${id}`;
+}
+
+function orderKey(id) {
+  return `rollon:order:${id}`;
+}
+
+function customerKey(id) {
+  return `rollon:customer:${id}`;
+}
+
+async function getJson(key) {
+  return runCommand('JSON.GET', key);
+}
+
+async function getAllFromSet(setKey, keyBuilder) {
+  const ids = await runCommand('SMEMBERS', setKey);
+  if (!ids || ids.length === 0) {
+    return [];
+  }
+
+  const commandList = ids.map((id) => ['JSON.GET', keyBuilder(id)]);
+  const result = await runPipeline(commandList);
+
+  return result
+    .map((entry) => entry.result)
+    .filter(Boolean)
+    .map((json) => JSON.parse(json));
+}
+
+async function saveMany(items, idxKey, keyBuilder) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return;
+  }
+
+  const commands = [];
+  for (const item of items) {
+    commands.push(['JSON.SET', keyBuilder(item.id), '$', JSON.stringify(item)]);
+    commands.push(['SADD', idxKey, item.id]);
+  }
+
+  await runPipeline(commands);
+}
+
+async function createOrder(order) {
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  const orderRecord = {
+    ...order,
+    id,
+    orderNumber: `ORD-${Date.now()}`,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const existingCustomerRaw = await getJson(customerKey(orderRecord.customerId));
+  const existingCustomer = existingCustomerRaw ? JSON.parse(existingCustomerRaw) : null;
+
+  const customerRecord = {
+    id: orderRecord.customerId,
+    name: orderRecord.customerName,
+    email: orderRecord.shippingAddress?.email || existingCustomer?.email || '',
+    phone: orderRecord.shippingAddress?.phone || existingCustomer?.phone || '',
+    totalSpent: Number(existingCustomer?.totalSpent || 0) + Number(orderRecord.total || 0),
+    orders: Number(existingCustomer?.orders || 0) + 1,
+    createdAt: existingCustomer?.createdAt || now,
+    city: orderRecord.shippingAddress?.city || existingCustomer?.city || '',
+    zone: orderRecord.shippingAddress?.zone || existingCustomer?.zone || '',
+    address: orderRecord.shippingAddress?.address || existingCustomer?.address || '',
+  };
+
+  await runPipeline([
+    ['JSON.SET', orderKey(id), '$', JSON.stringify(orderRecord)],
+    ['SADD', KEYS.orders, id],
+    ['JSON.SET', customerKey(orderRecord.customerId), '$', JSON.stringify(customerRecord)],
+    ['SADD', KEYS.customers, orderRecord.customerId],
+  ]);
+
+  return orderRecord;
+}
+
+module.exports = {
+  KEYS,
+  productKey,
+  categoryKey,
+  orderKey,
+  customerKey,
+  getJson,
+  getAllFromSet,
+  saveMany,
+  createOrder,
+};

--- a/api/_lib/seedData.generated.json
+++ b/api/_lib/seedData.generated.json
@@ -1,0 +1,561 @@
+{
+  "categories": [
+    {
+      "id": "1",
+      "name": "Vaporizers",
+      "slug": "vaporizers",
+      "description": "Premium vaping experience with our curated collection",
+      "image": "/images/category-vaporizers.jpg",
+      "icon": "Zap",
+      "productCount": 12,
+      "gradient": "from-blue-500 to-purple-600"
+    },
+    {
+      "id": "2",
+      "name": "Grinders",
+      "slug": "grinders",
+      "description": "Precision grinding tools for the perfect consistency",
+      "image": "/images/category-grinders.jpg",
+      "icon": "CircleDot",
+      "productCount": 18,
+      "gradient": "from-purple-500 to-pink-500"
+    },
+    {
+      "id": "3",
+      "name": "Water Pipes",
+      "slug": "water-pipes",
+      "description": "Smooth filtration for a refined experience",
+      "image": "/images/category-water-pipes.jpg",
+      "icon": "Droplets",
+      "productCount": 15,
+      "gradient": "from-cyan-500 to-blue-500"
+    },
+    {
+      "id": "4",
+      "name": "Rolling Papers",
+      "slug": "rolling-papers",
+      "description": "Classic collection of premium papers",
+      "image": "/images/category-rolling-papers.jpg",
+      "icon": "Scroll",
+      "productCount": 24,
+      "gradient": "from-amber-500 to-orange-500"
+    },
+    {
+      "id": "5",
+      "name": "Lighters",
+      "slug": "lighters",
+      "description": "Reliable ignition tools for every need",
+      "image": "/images/category-lighters.jpg",
+      "icon": "Flame",
+      "productCount": 20,
+      "gradient": "from-red-500 to-orange-500"
+    },
+    {
+      "id": "6",
+      "name": "Accessories",
+      "slug": "accessories",
+      "description": "Essential extras to complete your setup",
+      "image": "/images/category-accessories.jpg",
+      "icon": "Package",
+      "productCount": 30,
+      "gradient": "from-emerald-500 to-teal-500"
+    }
+  ],
+  "products": [
+    {
+      "id": "1",
+      "name": "Classic Design Four-Layer Aluminium Grinder",
+      "slug": "classic-aluminium-grinder-65mm",
+      "description": "Our grinder has a very strong magnetic cover. Even if it is turned upside down and shaken, it is strong enough to stay firm. The high-quality metal teeth have excellent durability for efficient grinding.",
+      "price": 1200,
+      "originalPrice": 1500,
+      "image": "/images/grinder-aluminium.jpg",
+      "category": "Grinders",
+      "categoryId": "2",
+      "tags": [
+        "grinder",
+        "aluminium",
+        "4-layer",
+        "65mm"
+      ],
+      "stock": 25,
+      "inStock": true,
+      "rating": 4.8,
+      "reviewCount": 42,
+      "specifications": {
+        "Material": "Aluminium",
+        "Diameter": "65mm",
+        "Layers": "4",
+        "Weight": "180g"
+      },
+      "featured": true
+    },
+    {
+      "id": "2",
+      "name": "Space Case 4-Part 60mm Aluminum Grinder",
+      "slug": "space-case-grinder-60mm",
+      "description": "Space Case 4 part 60mm aluminum Grinders are an investment that are built to last a lifetime. Featuring grinding teeth that never dull and a screen that doesn't clog.",
+      "price": 2500,
+      "image": "/images/grinder-space-case.jpg",
+      "category": "Grinders",
+      "categoryId": "2",
+      "tags": [
+        "grinder",
+        "space case",
+        "aluminum",
+        "premium"
+      ],
+      "stock": 15,
+      "inStock": true,
+      "rating": 4.9,
+      "reviewCount": 28,
+      "specifications": {
+        "Material": "Aerospace Aluminum",
+        "Diameter": "60mm",
+        "Layers": "4",
+        "Made in": "USA"
+      },
+      "featured": true
+    },
+    {
+      "id": "3",
+      "name": "Premium Dry Herb Vaporizer",
+      "slug": "premium-dry-herb-vaporizer",
+      "description": "Experience the ultimate vaping session with our premium dry herb vaporizer. Features precise temperature control, fast heat-up time, and long-lasting battery.",
+      "price": 8500,
+      "salePrice": 7200,
+      "image": "/images/vaporizer-dry-herb.jpg",
+      "category": "Vaporizers",
+      "categoryId": "1",
+      "tags": [
+        "vaporizer",
+        "dry herb",
+        "digital",
+        "premium"
+      ],
+      "stock": 10,
+      "inStock": true,
+      "rating": 4.7,
+      "reviewCount": 35,
+      "specifications": {
+        "Temperature Range": "320-430F",
+        "Battery": "3000mAh",
+        "Heat-up Time": "30 seconds",
+        "Charging": "USB-C"
+      },
+      "featured": true
+    },
+    {
+      "id": "4",
+      "name": "OCB Organic Hemp Rolling Papers",
+      "slug": "ocb-organic-hemp-papers",
+      "description": "Natural unbleached organic hemp rolling papers. Slow-burning, ultra-thin papers for a smooth smoking experience.",
+      "price": 250,
+      "image": "/images/papers-ocb.jpg",
+      "category": "Rolling Papers",
+      "categoryId": "4",
+      "tags": [
+        "papers",
+        "ocb",
+        "organic",
+        "hemp"
+      ],
+      "stock": 100,
+      "inStock": true,
+      "rating": 4.6,
+      "reviewCount": 89,
+      "specifications": {
+        "Material": "Organic Hemp",
+        "Size": "1 1/4",
+        "Leaves per pack": "50",
+        "Origin": "France"
+      },
+      "featured": true
+    },
+    {
+      "id": "5",
+      "name": "RAW Classic King Size Slim",
+      "slug": "raw-classic-king-size",
+      "description": "The classic RAW rolling papers in king size slim. Natural unrefined papers with RAW's signature criss-cross watermark.",
+      "price": 180,
+      "image": "/images/papers-raw.jpg",
+      "category": "Rolling Papers",
+      "categoryId": "4",
+      "tags": [
+        "papers",
+        "raw",
+        "classic",
+        "king size"
+      ],
+      "stock": 150,
+      "inStock": true,
+      "rating": 4.8,
+      "reviewCount": 156,
+      "specifications": {
+        "Material": "Natural Unrefined",
+        "Size": "King Size Slim",
+        "Leaves per pack": "32",
+        "Origin": "Spain"
+      },
+      "featured": false
+    },
+    {
+      "id": "6",
+      "name": "Clipper Refillable Lighter",
+      "slug": "clipper-refillable-lighter",
+      "description": "The iconic Clipper lighter with its classic round design. Refillable gas and replaceable flint make it an eco-friendly choice.",
+      "price": 450,
+      "image": "/images/lighter-clipper.jpg",
+      "category": "Lighters",
+      "categoryId": "5",
+      "tags": [
+        "lighter",
+        "clipper",
+        "refillable",
+        "classic"
+      ],
+      "stock": 60,
+      "inStock": true,
+      "rating": 4.7,
+      "reviewCount": 73,
+      "specifications": {
+        "Type": "Flint Wheel",
+        "Fuel": "Butane",
+        "Refillable": "Yes",
+        "Made in": "Spain"
+      },
+      "featured": true
+    },
+    {
+      "id": "7",
+      "name": "Electric Arc Plasma Lighter",
+      "slug": "electric-arc-lighter",
+      "description": "Modern USB rechargeable plasma lighter. Windproof, flameless design with LED indicator. Perfect for outdoor use.",
+      "price": 1200,
+      "salePrice": 950,
+      "image": "/images/lighter-electric.jpg",
+      "category": "Lighters",
+      "categoryId": "5",
+      "tags": [
+        "lighter",
+        "electric",
+        "plasma",
+        "usb rechargeable"
+      ],
+      "stock": 40,
+      "inStock": true,
+      "rating": 4.5,
+      "reviewCount": 48,
+      "specifications": {
+        "Type": "Plasma Arc",
+        "Battery": "280mAh",
+        "Charging": "USB",
+        "Windproof": "Yes"
+      },
+      "featured": true,
+      "new": true
+    },
+    {
+      "id": "8",
+      "name": "5 Inch Mini Silicone Water Pipe",
+      "slug": "mini-silicone-water-pipe",
+      "description": "Portable 5 inch unbreakable silicone water pipe with detachable design. Perfect for travel and outdoor adventures.",
+      "price": 1750,
+      "image": "/images/bong-mini-silicone.jpg",
+      "category": "Water Pipes",
+      "categoryId": "3",
+      "tags": [
+        "water pipe",
+        "silicone",
+        "portable",
+        "unbreakable"
+      ],
+      "stock": 30,
+      "inStock": true,
+      "rating": 4.6,
+      "reviewCount": 52,
+      "specifications": {
+        "Material": "Food-grade Silicone",
+        "Height": "5 inch",
+        "Bowl": "Glass",
+        "Detachable": "Yes"
+      },
+      "featured": true
+    },
+    {
+      "id": "9",
+      "name": "Zippo Classic Windproof Lighter",
+      "slug": "zippo-classic-lighter",
+      "description": "The legendary Zippo windproof lighter. Iconic design, lifetime guarantee, and that satisfying click. Made in USA.",
+      "price": 3500,
+      "image": "/images/lighter-zippo.jpg",
+      "category": "Lighters",
+      "categoryId": "5",
+      "tags": [
+        "lighter",
+        "zippo",
+        "windproof",
+        "classic"
+      ],
+      "stock": 20,
+      "inStock": true,
+      "rating": 4.9,
+      "reviewCount": 67,
+      "specifications": {
+        "Type": "Flint Wheel",
+        "Fuel": "Zippo Fluid",
+        "Made in": "USA",
+        "Warranty": "Lifetime"
+      },
+      "featured": true
+    },
+    {
+      "id": "10",
+      "name": "Portable Vape Pen Starter Kit",
+      "slug": "portable-vape-pen-kit",
+      "description": "Slim and discreet vape pen starter kit. Perfect for beginners with easy one-button operation and USB charging.",
+      "price": 2800,
+      "salePrice": 2200,
+      "image": "/images/vape-pen-portable.jpg",
+      "category": "Vaporizers",
+      "categoryId": "1",
+      "tags": [
+        "vape pen",
+        "starter kit",
+        "portable",
+        "beginner"
+      ],
+      "stock": 35,
+      "inStock": true,
+      "rating": 4.4,
+      "reviewCount": 41,
+      "specifications": {
+        "Battery": "650mAh",
+        "Charging": "USB",
+        "Tank Capacity": "1.6ml",
+        "Coil": "1.6ohm"
+      },
+      "featured": false,
+      "new": true
+    },
+    {
+      "id": "11",
+      "name": "Bamboo Rolling Tray Large",
+      "slug": "bamboo-rolling-tray",
+      "description": "Eco-friendly bamboo rolling tray with smooth finish and raised edges. Perfect size for rolling with compartments for accessories.",
+      "price": 850,
+      "image": "/images/tray-wooden.jpg",
+      "category": "Accessories",
+      "categoryId": "6",
+      "tags": [
+        "tray",
+        "bamboo",
+        "rolling",
+        "eco-friendly"
+      ],
+      "stock": 45,
+      "inStock": true,
+      "rating": 4.7,
+      "reviewCount": 38,
+      "specifications": {
+        "Material": "Bamboo",
+        "Size": "Large (28x18cm)",
+        "Finish": "Natural",
+        "Features": "Raised edges"
+      },
+      "featured": true
+    },
+    {
+      "id": "12",
+      "name": "Amber Glass Storage Jar 250ml",
+      "slug": "amber-glass-storage-jar",
+      "description": "UV-protected amber glass jar with airtight bamboo lid. Keeps herbs fresh and preserves potency. Smell-proof design.",
+      "price": 650,
+      "image": "/images/jar-storage.jpg",
+      "category": "Accessories",
+      "categoryId": "6",
+      "tags": [
+        "jar",
+        "storage",
+        "glass",
+        "uv-protected"
+      ],
+      "stock": 55,
+      "inStock": true,
+      "rating": 4.8,
+      "reviewCount": 62,
+      "specifications": {
+        "Material": "Amber Glass",
+        "Capacity": "250ml",
+        "Lid": "Bamboo",
+        "Features": "UV Protection"
+      },
+      "featured": false
+    },
+    {
+      "id": "13",
+      "name": "Digital Pocket Scale 0.01g Precision",
+      "slug": "digital-pocket-scale",
+      "description": "High-precision digital scale with 0.01g accuracy. Backlit LCD display, stainless steel platform, and auto-calibration.",
+      "price": 1200,
+      "salePrice": 950,
+      "image": "/images/scale-digital.jpg",
+      "category": "Accessories",
+      "categoryId": "6",
+      "tags": [
+        "scale",
+        "digital",
+        "precision",
+        "pocket"
+      ],
+      "stock": 40,
+      "inStock": true,
+      "rating": 4.6,
+      "reviewCount": 29,
+      "specifications": {
+        "Precision": "0.01g",
+        "Max Weight": "200g",
+        "Display": "LCD Backlit",
+        "Power": "AAA Batteries"
+      },
+      "featured": true
+    },
+    {
+      "id": "14",
+      "name": "Automatic Cigarette Rolling Machine",
+      "slug": "automatic-rolling-machine",
+      "description": "Electric automatic rolling machine for perfect cigarettes every time. Easy to use with adjustable density settings.",
+      "price": 2200,
+      "image": "/images/roller-machine.jpg",
+      "category": "Accessories",
+      "categoryId": "6",
+      "tags": [
+        "roller",
+        "automatic",
+        "electric",
+        "machine"
+      ],
+      "stock": 18,
+      "inStock": true,
+      "rating": 4.5,
+      "reviewCount": 22,
+      "specifications": {
+        "Type": "Electric",
+        "Power": "Battery/USB",
+        "Compatibility": "Standard papers",
+        "Features": "Adjustable density"
+      },
+      "featured": false
+    },
+    {
+      "id": "15",
+      "name": "Hand-Blown Glass Spoon Pipe",
+      "slug": "glass-spoon-pipe",
+      "description": "Beautiful hand-blown glass spoon pipe with unique swirled colors. Each piece is one-of-a-kind. Thick borosilicate glass.",
+      "price": 1500,
+      "image": "/images/pipe-glass-spoon.jpg",
+      "category": "Water Pipes",
+      "categoryId": "3",
+      "tags": [
+        "pipe",
+        "glass",
+        "spoon",
+        "hand-blown"
+      ],
+      "stock": 22,
+      "inStock": true,
+      "rating": 4.7,
+      "reviewCount": 33,
+      "specifications": {
+        "Material": "Borosilicate Glass",
+        "Length": "4 inch",
+        "Style": "Spoon",
+        "Features": "Hand-blown"
+      },
+      "featured": true,
+      "new": true
+    },
+    {
+      "id": "16",
+      "name": "Wooden Dugout with Metal Bat",
+      "slug": "wooden-dugout-kit",
+      "description": "Classic wooden dugout with sliding lid and included metal bat pipe. Discreet and portable for on-the-go use.",
+      "price": 1100,
+      "image": "/images/dugout-wooden.jpg",
+      "category": "Accessories",
+      "categoryId": "6",
+      "tags": [
+        "dugout",
+        "wooden",
+        "bat",
+        "portable"
+      ],
+      "stock": 28,
+      "inStock": true,
+      "rating": 4.4,
+      "reviewCount": 19,
+      "specifications": {
+        "Material": "Wood",
+        "Includes": "Metal bat pipe",
+        "Lid": "Sliding",
+        "Size": "Compact"
+      },
+      "featured": false
+    },
+    {
+      "id": "17",
+      "name": "Concentrate Vaporizer Pen",
+      "slug": "concentrate-vaporizer-pen",
+      "description": "Premium concentrate vaporizer with ceramic coil and variable voltage. Sleek design with preheat function.",
+      "price": 4500,
+      "salePrice": 3800,
+      "image": "/images/vaporizer-concentrate.jpg",
+      "category": "Vaporizers",
+      "categoryId": "1",
+      "tags": [
+        "vaporizer",
+        "concentrate",
+        "ceramic",
+        "variable voltage"
+      ],
+      "stock": 15,
+      "inStock": true,
+      "rating": 4.8,
+      "reviewCount": 27,
+      "specifications": {
+        "Coil": "Ceramic",
+        "Voltage": "Variable (3.3-4.8V)",
+        "Battery": "900mAh",
+        "Features": "Preheat function"
+      },
+      "featured": true
+    },
+    {
+      "id": "18",
+      "name": "Premium Glass Water Pipe 12\"",
+      "slug": "premium-glass-bong-12inch",
+      "description": "High-quality borosilicate glass water pipe with beaker base, ice catcher, and removable downstem. Smooth hits guaranteed.",
+      "price": 5500,
+      "image": "/images/bong-glass-premium.jpg",
+      "category": "Water Pipes",
+      "categoryId": "3",
+      "tags": [
+        "water pipe",
+        "glass",
+        "beaker",
+        "ice catcher"
+      ],
+      "stock": 12,
+      "inStock": true,
+      "rating": 4.9,
+      "reviewCount": 45,
+      "specifications": {
+        "Material": "Borosilicate Glass",
+        "Height": "12 inch",
+        "Base": "Beaker",
+        "Features": "Ice Catcher"
+      },
+      "featured": true
+    }
+  ]
+}

--- a/api/_lib/seedData.js
+++ b/api/_lib/seedData.js
@@ -1,0 +1,6 @@
+const seedDataset = require('./seedData.generated.json');
+
+module.exports = {
+  categories: seedDataset.categories,
+  products: seedDataset.products,
+};

--- a/api/_lib/upstash.js
+++ b/api/_lib/upstash.js
@@ -1,0 +1,53 @@
+const REQUIRED_ENV = ['RollON_Database_KV_REST_API_URL', 'RollON_Database_KV_REST_API_TOKEN'];
+
+function assertEnv() {
+  const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
+async function runCommand(command, ...args) {
+  assertEnv();
+  const response = await fetch(process.env.RollON_Database_KV_REST_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.RollON_Database_KV_REST_API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([command, ...args]),
+  });
+
+  const body = await response.json();
+
+  if (!response.ok || body.error) {
+    throw new Error(body.error || `Redis command failed (${response.status})`);
+  }
+
+  return body.result;
+}
+
+async function runPipeline(commands) {
+  assertEnv();
+
+  const response = await fetch(`${process.env.RollON_Database_KV_REST_API_URL}/pipeline`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.RollON_Database_KV_REST_API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(commands),
+  });
+
+  const body = await response.json();
+  if (!response.ok || body.error) {
+    throw new Error(body.error || `Redis pipeline failed (${response.status})`);
+  }
+
+  return body;
+}
+
+module.exports = {
+  runCommand,
+  runPipeline,
+};

--- a/api/admin/seed.js
+++ b/api/admin/seed.js
@@ -1,0 +1,27 @@
+const { withErrorHandling, sendJson } = require('../_lib/http');
+const { saveMany, KEYS, productKey, categoryKey } = require('../_lib/repositories');
+const { categories, products } = require('../_lib/seedData');
+
+module.exports = withErrorHandling(async (req, res) => {
+  if (req.method !== 'POST') {
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  if (!process.env.ROLLON_ADMIN_SEED_TOKEN) {
+    return sendJson(res, 500, { error: 'ROLLON_ADMIN_SEED_TOKEN is not configured' });
+  }
+
+  const authToken = req.headers['x-admin-token'];
+  if (authToken !== process.env.ROLLON_ADMIN_SEED_TOKEN) {
+    return sendJson(res, 401, { error: 'Unauthorized' });
+  }
+
+  await saveMany(categories, KEYS.categories, categoryKey);
+  await saveMany(products, KEYS.products, productKey);
+
+  return sendJson(res, 200, {
+    message: 'Seed completed successfully',
+    categories: categories.length,
+    products: products.length,
+  });
+});

--- a/api/categories/index.js
+++ b/api/categories/index.js
@@ -1,0 +1,11 @@
+const { withErrorHandling, sendJson } = require('../_lib/http');
+const { KEYS, categoryKey, getAllFromSet } = require('../_lib/repositories');
+
+module.exports = withErrorHandling(async (req, res) => {
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  const categories = await getAllFromSet(KEYS.categories, categoryKey);
+  sendJson(res, 200, categories);
+});

--- a/api/customers/index.js
+++ b/api/customers/index.js
@@ -1,0 +1,11 @@
+const { withErrorHandling, sendJson } = require('../_lib/http');
+const { KEYS, customerKey, getAllFromSet } = require('../_lib/repositories');
+
+module.exports = withErrorHandling(async (req, res) => {
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  const customers = await getAllFromSet(KEYS.customers, customerKey);
+  sendJson(res, 200, customers);
+});

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,11 @@
+const { withErrorHandling, sendJson } = require('./_lib/http');
+const { runCommand } = require('./_lib/upstash');
+
+module.exports = withErrorHandling(async (req, res) => {
+  const ping = await runCommand('PING');
+  sendJson(res, 200, {
+    status: 'ok',
+    redis: ping,
+    timestamp: new Date().toISOString(),
+  });
+});

--- a/api/orders/index.js
+++ b/api/orders/index.js
@@ -1,0 +1,26 @@
+const { withErrorHandling, sendJson } = require('../_lib/http');
+const { KEYS, orderKey, getAllFromSet, getJson, createOrder } = require('../_lib/repositories');
+
+module.exports = withErrorHandling(async (req, res) => {
+  if (req.method === 'GET') {
+    if (req.query.id) {
+      const order = await getJson(orderKey(String(req.query.id)));
+      return sendJson(res, order ? 200 : 404, order ? JSON.parse(order) : { error: 'Not found' });
+    }
+
+    const orders = await getAllFromSet(KEYS.orders, orderKey);
+    return sendJson(res, 200, orders);
+  }
+
+  if (req.method === 'POST') {
+    const payload = req.body;
+    if (!payload || !payload.customerId || !payload.customerName || !Array.isArray(payload.items)) {
+      return sendJson(res, 400, { error: 'Invalid order payload' });
+    }
+
+    const order = await createOrder(payload);
+    return sendJson(res, 201, order);
+  }
+
+  return sendJson(res, 405, { error: 'Method not allowed' });
+});

--- a/api/products/index.js
+++ b/api/products/index.js
@@ -1,0 +1,42 @@
+const { withErrorHandling, sendJson } = require('../_lib/http');
+const { KEYS, productKey, getAllFromSet, getJson } = require('../_lib/repositories');
+
+module.exports = withErrorHandling(async (req, res) => {
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  const { id, slug, categoryId, featured, search } = req.query;
+
+  if (id) {
+    const product = await getJson(productKey(String(id)));
+    return sendJson(res, product ? 200 : 404, product ? JSON.parse(product) : { error: 'Not found' });
+  }
+
+  let products = await getAllFromSet(KEYS.products, productKey);
+
+  if (slug) {
+    const bySlug = products.find((p) => p.slug === slug);
+    return sendJson(res, bySlug ? 200 : 404, bySlug || { error: 'Not found' });
+  }
+
+  if (categoryId) {
+    products = products.filter((product) => product.categoryId === categoryId);
+  }
+
+  if (featured === 'true') {
+    products = products.filter((product) => Boolean(product.featured));
+  }
+
+  if (search) {
+    const query = String(search).toLowerCase();
+    products = products.filter((product) => {
+      const matchesName = product.name.toLowerCase().includes(query);
+      const matchesDescription = product.description.toLowerCase().includes(query);
+      const matchesTags = Array.isArray(product.tags) && product.tags.some((tag) => tag.toLowerCase().includes(query));
+      return matchesName || matchesDescription || matchesTags;
+    });
+  }
+
+  return sendJson(res, 200, products);
+});

--- a/docs/catalog-research.md
+++ b/docs/catalog-research.md
@@ -1,0 +1,24 @@
+# Catalog Research Notes (Rollon Facebook + Internal Data)
+
+## Sources Reviewed
+
+1. Public Facebook profile URL provided by stakeholder: `https://www.facebook.com/profile.php?id=61559641950523`
+2. Canonical in-repo product dataset: `rollon-app/src/data/products.ts`
+
+## Facebook Findings (public metadata only)
+
+From publicly accessible Open Graph tags (without authenticated scraping):
+
+- Page identity: **Rollon'**
+- Location signal: **Dhaka**
+- Category: **E-commerce website**
+- Engagement snapshot in metadata at time of fetch: **130 likes**, **16 talking about this**
+
+## Why product rows were sourced from app data
+
+Facebook profile HTML does not expose a stable, structured product-feed API in public unauthenticated markup. To avoid hallucinated catalog entries, the database seed now uses the repository's canonical product + category dataset that the storefront already renders.
+
+## Outcome
+
+- Database seeding now mirrors the live storefront taxonomy and catalog (6 categories, 18 products).
+- Brand metadata from Facebook can be used in marketing/profile tables later, but product truth remains application-owned.

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -1,0 +1,48 @@
+# RollON Database Architecture (Vercel + Upstash Redis)
+
+## Environment Variables Analysis
+
+The Vercel integration created **Upstash Redis** credentials:
+
+- `RollON_Database_KV_REST_API_READ_ONLY_TOKEN`: Read-only REST token for safe analytics/query usage.
+- `RollON_Database_KV_REST_API_TOKEN`: Read-write REST token for backend mutations.
+- `RollON_Database_KV_REST_API_URL`: HTTPS endpoint used by serverless functions to execute Redis commands.
+- `RollON_Database_KV_URL` / `RollON_Database_REDIS_URL`: Redis connection strings (TLS) for SDK clients.
+
+## Data Model
+
+Key namespace and indexing strategy:
+
+- `rollon:product:{id}` + set index `rollon:idx:products`
+- `rollon:category:{id}` + set index `rollon:idx:categories`
+- `rollon:order:{id}` + set index `rollon:idx:orders`
+- `rollon:customer:{id}` + set index `rollon:idx:customers`
+
+All entities are stored as JSON documents (`JSON.SET`) for schema flexibility.
+
+Seed source of truth:
+- `api/_lib/seedData.generated.json` (generated from `rollon-app/src/data/products.ts`)
+- Current baseline size: 6 categories, 18 products.
+
+## API Endpoints
+
+- `GET /api/health` → health + Redis ping
+- `GET /api/products` with filters (`id`, `slug`, `categoryId`, `featured`, `search`)
+- `GET /api/categories`
+- `GET /api/orders`, `GET /api/orders?id=...`, `POST /api/orders`
+- `GET /api/customers`
+- `POST /api/admin/seed` (requires `x-admin-token` header and `ROLLON_ADMIN_SEED_TOKEN`)
+
+## Frontend Integration
+
+`rollon-app/src/lib/api.ts` now supports two modes:
+
+- `VITE_USE_REMOTE_API=true` → fetches from `/api/*` (serverless + Upstash)
+- fallback mode → current local mock dataset to keep development and tests stable
+
+## Production Notes
+
+- Keep token values only in Vercel Environment Variables.
+- Use read-only token for dashboards where writes are not needed.
+- Rotate tokens regularly.
+- Seed endpoint is protected by a separate admin token.

--- a/rollon-app/.env.example
+++ b/rollon-app/.env.example
@@ -1,5 +1,6 @@
 # API Configuration
-VITE_API_URL=http://localhost:4000/api
+VITE_API_BASE_URL=/api
+VITE_USE_REMOTE_API=false
 
 # Payment Gateway — Bangladesh
 # Get credentials from: https://sslcommerz.com/

--- a/rollon-app/src/lib/api.ts
+++ b/rollon-app/src/lib/api.ts
@@ -1,7 +1,16 @@
-import { products as mockProducts, categories as mockCategories, testimonials as mockTestimonials, orders as mockOrders, customers as mockCustomers, paymentMethods } from '../data/products';
-import type { Order } from '@/types';
+import {
+  products as mockProducts,
+  categories as mockCategories,
+  testimonials as mockTestimonials,
+  orders as mockOrders,
+  customers as mockCustomers,
+  paymentMethods,
+} from '../data/products';
+import type { Category, Customer, Order, Product, Testimonial } from '@/types';
 
 const API_DELAY = 300;
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+const USE_REMOTE = import.meta.env.VITE_USE_REMOTE_API === 'true';
 
 const simulateApiCall = <T>(data: T): Promise<T> => {
   return new Promise((resolve) => {
@@ -9,101 +18,126 @@ const simulateApiCall = <T>(data: T): Promise<T> => {
   });
 };
 
+const fetchJson = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed (${response.status})`);
+  }
+
+  return response.json();
+};
+
+const withFallback = async <T>(remoteFn: () => Promise<T>, mockFn: () => Promise<T>) => {
+  if (!USE_REMOTE) {
+    return mockFn();
+  }
+
+  try {
+    return await remoteFn();
+  } catch (error) {
+    console.warn('Remote API unavailable, falling back to local dataset.', error);
+    return mockFn();
+  }
+};
+
 export const api = {
   products: {
-    getAll: async () => {
-      return simulateApiCall(mockProducts);
-    },
+    getAll: async () => withFallback<Product[]>(() => fetchJson('/products'), () => simulateApiCall(mockProducts)),
 
-    getById: async (id: string) => {
-      const product = mockProducts.find(p => p.id === id);
-      return simulateApiCall(product);
-    },
+    getById: async (id: string) =>
+      withFallback<Product | undefined>(() => fetchJson(`/products?id=${id}`), async () => mockProducts.find((p) => p.id === id)),
 
-    getBySlug: async (slug: string) => {
-      const product = mockProducts.find(p => p.slug === slug);
-      return simulateApiCall(product);
-    },
+    getBySlug: async (slug: string) =>
+      withFallback<Product | undefined>(
+        () => fetchJson(`/products?slug=${encodeURIComponent(slug)}`),
+        async () => mockProducts.find((p) => p.slug === slug),
+      ),
 
-    getByCategory: async (categoryId: string) => {
-      const filtered = mockProducts.filter(p => p.categoryId === categoryId);
-      return simulateApiCall(filtered);
-    },
+    getByCategory: async (categoryId: string) =>
+      withFallback<Product[]>(
+        () => fetchJson(`/products?categoryId=${encodeURIComponent(categoryId)}`),
+        async () => mockProducts.filter((p) => p.categoryId === categoryId),
+      ),
 
-    getFeatured: async () => {
-      const featured = mockProducts.filter(p => p.featured);
-      return simulateApiCall(featured);
-    },
+    getFeatured: async () =>
+      withFallback<Product[]>(() => fetchJson('/products?featured=true'), async () => mockProducts.filter((p) => p.featured)),
 
-    search: async (query: string) => {
-      const lowerQuery = query.toLowerCase();
-      const results = mockProducts.filter(p => 
-        p.name.toLowerCase().includes(lowerQuery) ||
-        p.description.toLowerCase().includes(lowerQuery) ||
-        p.tags?.some(t => t.toLowerCase().includes(lowerQuery))
-      );
-      return simulateApiCall(results);
-    },
+    search: async (query: string) =>
+      withFallback<Product[]>(
+        () => fetchJson(`/products?search=${encodeURIComponent(query)}`),
+        async () => {
+          const lowerQuery = query.toLowerCase();
+          return mockProducts.filter(
+            (p) =>
+              p.name.toLowerCase().includes(lowerQuery) ||
+              p.description.toLowerCase().includes(lowerQuery) ||
+              p.tags?.some((t) => t.toLowerCase().includes(lowerQuery)),
+          );
+        },
+      ),
   },
 
   categories: {
-    getAll: async () => {
-      return simulateApiCall(mockCategories);
-    },
+    getAll: async () => withFallback<Category[]>(() => fetchJson('/categories'), () => simulateApiCall(mockCategories)),
 
-    getById: async (id: string) => {
-      const category = mockCategories.find(c => c.id === id);
-      return simulateApiCall(category);
-    },
+    getById: async (id: string) =>
+      withFallback<Category | undefined>(async () => {
+        const categories = await fetchJson<Category[]>('/categories');
+        return categories.find((c) => c.id === id);
+      }, async () => mockCategories.find((c) => c.id === id)),
 
-    getBySlug: async (slug: string) => {
-      const category = mockCategories.find(c => c.slug === slug);
-      return simulateApiCall(category);
-    },
+    getBySlug: async (slug: string) =>
+      withFallback<Category | undefined>(async () => {
+        const categories = await fetchJson<Category[]>('/categories');
+        return categories.find((c) => c.slug === slug);
+      }, async () => mockCategories.find((c) => c.slug === slug)),
   },
 
   testimonials: {
-    getAll: async () => {
-      return simulateApiCall(mockTestimonials);
-    },
+    getAll: async () => simulateApiCall<Testimonial[]>(mockTestimonials),
   },
 
   orders: {
-    getAll: async () => {
-      return simulateApiCall(mockOrders);
-    },
+    getAll: async () => withFallback<Order[]>(() => fetchJson('/orders'), () => simulateApiCall(mockOrders)),
 
-    getById: async (id: string) => {
-      const order = mockOrders.find(o => o.id === id);
-      return simulateApiCall(order);
-    },
+    getById: async (id: string) =>
+      withFallback<Order | undefined>(() => fetchJson(`/orders?id=${id}`), async () => mockOrders.find((o) => o.id === id)),
 
-    create: async (order: Omit<Order, 'id' | 'orderNumber' | 'createdAt' | 'updatedAt'>) => {
-      const newOrder = {
-        ...order,
-        id: Math.random().toString(36).substr(2, 9),
-        orderNumber: `ORD-${Date.now()}`,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      return simulateApiCall(newOrder);
-    },
+    create: async (order: Omit<Order, 'id' | 'orderNumber' | 'createdAt' | 'updatedAt'>) =>
+      withFallback<Order>(
+        () =>
+          fetchJson('/orders', {
+            method: 'POST',
+            body: JSON.stringify(order),
+          }),
+        async () => ({
+          ...order,
+          id: Math.random().toString(36).slice(2, 11),
+          orderNumber: `ORD-${Date.now()}`,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+      ),
   },
 
   customers: {
-    getAll: async () => {
-      return simulateApiCall(mockCustomers);
-    },
+    getAll: async () => withFallback<Customer[]>(() => fetchJson('/customers'), () => simulateApiCall(mockCustomers)),
 
-    getById: async (id: string) => {
-      const customer = mockCustomers.find(c => c.id === id);
-      return simulateApiCall(customer);
-    },
+    getById: async (id: string) =>
+      withFallback<Customer | undefined>(async () => {
+        const customers = await fetchJson<Customer[]>('/customers');
+        return customers.find((c) => c.id === id);
+      }, async () => mockCustomers.find((c) => c.id === id)),
   },
 
   payment: {
-    getMethods: async () => {
-      return simulateApiCall(paymentMethods);
-    },
+    getMethods: async () => simulateApiCall(paymentMethods),
   },
 };

--- a/scripts/sync-seed-from-frontend.mjs
+++ b/scripts/sync-seed-from-frontend.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+import ts from '../rollon-app/node_modules/typescript/lib/typescript.js';
+
+const sourcePath = new URL('../rollon-app/src/data/products.ts', import.meta.url);
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+  },
+}).outputText;
+
+const sandbox = {
+  exports: {},
+  module: { exports: {} },
+  require: () => ({}),
+};
+vm.createContext(sandbox);
+vm.runInContext(transpiled, sandbox);
+
+const { categories, products } = sandbox.exports;
+
+if (!Array.isArray(categories) || !Array.isArray(products)) {
+  throw new Error('Could not extract categories/products from frontend dataset.');
+}
+
+const outputPath = new URL('../api/_lib/seedData.generated.json', import.meta.url);
+fs.writeFileSync(outputPath, JSON.stringify({ categories, products }, null, 2));
+
+console.log(`Seed synced: ${categories.length} categories, ${products.length} products`);

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
   "outputDirectory": "rollon-app/dist",
   "framework": "vite",
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
### Motivation

- Provide a production-ready serverless API backed by Upstash Redis to serve products, categories, orders, and customers from the deployed site. 
- Ensure the backend seed mirrors the frontend canonical dataset by generating and shipping a JSON seed that can be written to Redis via a protected admin endpoint. 
- Allow the React frontend to toggle between the local mock dataset and the remote serverless API using environment variables and enable proper routing on Vercel.

### Description

- Added new serverless endpoints and helpers under `api/*`, including `products`, `categories`, `orders`, `customers`, `admin/seed`, and `health`, plus `api/_lib/http.js` for unified JSON responses and error handling. 
- Implemented Upstash REST helpers in `api/_lib/upstash.js` and repository-layer logic in `api/_lib/repositories.js` (JSON storage, set indexes, `createOrder` and related key helpers), and included generated seed data at `api/_lib/seedData.generated.json` with a small wrapper `api/_lib/seedData.js`. 
- Updated frontend API client in `rollon-app/src/lib/api.ts` to use `VITE_API_BASE_URL` and `VITE_USE_REMOTE_API`, introduced `fetchJson` and `withFallback` behavior to fall back to local mocks if the remote API is unavailable. 
- Added automation and infra-related files including `scripts/sync-seed-from-frontend.mjs` to regenerate the seed from the frontend dataset, `vercel.json` rewrite for `/api/*`, updated `rollon-app/.env.example` and README, and new docs `docs/database-architecture.md` and `docs/catalog-research.md`.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e32119308328b5c36829bba18405)